### PR TITLE
add pre-command option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,13 @@ inputs:
     description: 'keyword for excluding check'
     required: false
     default: ''
+  pre-command:
+    description: 'pre-command which is executed before running clang-tidy'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.exclude }}
+    - ${{ inputs.pre-command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,15 @@ set -e
 
 # handle argument
 EXCLUDE=$1
+PRE_COMMAND=$2
+
 echo "EXCLUDE=$EXCLUDE"
+echo "PRE_COMMAND=$PRE_COMMAND"
+
+# execute pre-command if exist
+if [ ! -z "$PRE_COMMAND" ]; then
+    /bin/bash -c "$PRE_COMMAND"
+fi    
 
 # execute clang-tidy
 source /run_clang_tidy.sh $EXCLUDE


### PR DESCRIPTION
It add the pre-command option for setting command
which is executed before runing clang-tidy.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>